### PR TITLE
Use default JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,4 @@ addons:
     - imagemagick
     - xdotool
   firefox: "49.0"
-install: 
-- echo $JAVA_HOME
-- ls -l /usr/lib/jvm
-- readlink -f $(which java)
-- mvn compile test-compile --show-version --batch-mode
 script: mvn verify -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: trusty
 sudo: false
 group: beta
 language: java
-jdk:
-  - oraclejdk8
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
   firefox: "49.0"
 install: 
 - echo $JAVA_HOME
-- ls -l $(which java)
+- ls -l /usr/lib/jvm
 - readlink -f $(which java)
 - mvn compile test-compile --show-version --batch-mode
 script: mvn verify -B


### PR DESCRIPTION
Travis started having an issue with the Oracle Java 8 directory name not being correctly set when the jdk_switcher was configured. This resolves it by just using the default JDK (which is Oracle Java 8 on the Trusty container we're now using).